### PR TITLE
Updated Installation Instruction to be compatible with latest NvChad release 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,10 +475,14 @@ Also vimacs comes with a lot of dependencies. Follow the instructions on
 > Make INSTALL Script more interactive
 
 ```sh
-git clone https://github.com/NvChad/NvChad ~/.config/nvim --depth 1
+git clone https://github.com/NvChad/starter ~/.config/nvim 
 git clone https://github.com/UTFeight/vimacs
 cd vimacs && mv custom ~/.config/nvim/lua/custom
-cd .. && rm -rf vimacs && nvim
+cd .. && rm -rf vimacs 
+# Migration script for latest NvChad (custom folder not supported)
+git clone https://gist.github.com/048bed2e7570569e6b327b35d1715404.git upgradeNvChad2.5
+cd upgradeNvChad2.5 && chmod +x migrate.sh && ./migrate.sh
+cd .. && rm -rf upgradeNvChad2.5
 ```
 
 1. Neotest:

--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ git clone https://github.com/UTFeight/vimacs
 cd vimacs && mv custom ~/.config/nvim/lua/custom
 cd .. && rm -rf vimacs 
 # Migration script for latest NvChad (custom folder not supported)
+# Check https://nvchad.com/news/v2.5_release for details
 git clone https://gist.github.com/048bed2e7570569e6b327b35d1715404.git upgradeNvChad2.5
 cd upgradeNvChad2.5 && chmod +x migrate.sh && ./migrate.sh
 cd .. && rm -rf upgradeNvChad2.5


### PR DESCRIPTION
NvChad release 2.5 do not support `custom` folder anymore (as well as a few other minor changes, all described in their [Release announcement](https://nvchad.com/news/v2.5_release#migration))

Since they provide a migration script which works well out of the box, I have updated the installation instruction with the extra steps required to run the migration script.

Also, NvChad base repo for installation has changed, as documented in the install docs, so I have update this as well. 

It should work fine and save someone else 1h of digging around.